### PR TITLE
Removed node based fs directory manipulation

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,11 +46,9 @@
     "sinon-chai": "^2.7.0"
   },
   "dependencies": {
-    "class-extend": "^0.1.1",
     "drudgeon": "^0.1.7",
     "ejs": "^2.3.1",
     "lodash": "^3.6.0",
-    "mkdirp": "^0.5.0",
     "when": "^3.7.2",
     "yeoman-generator": "^0.20.1"
   }

--- a/spec/behavior/expander.spec.js
+++ b/spec/behavior/expander.spec.js
@@ -20,13 +20,7 @@ var fs = {
 	write: write
 };
 
-var expand = proxyquire( "../src/expander", {
-	mkdirp: {
-		sync: function() {
-			return when.resolve();
-		}
-	}
-} );
+var expand = proxyquire( "../src/expander", {} );
 
 describe( "Expanding Templates", function() {
 	var files;

--- a/src/expander.js
+++ b/src/expander.js
@@ -1,7 +1,5 @@
 var path = require( "path" );
 var _ = require( "lodash" );
-var nodeFS = require( "fs" );
-var mkdirp = require( "mkdirp" );
 var ejs = require( "ejs" );
 
 var defaultContext = {
@@ -21,7 +19,6 @@ function expand( fs, base, target, context, state, files, structure ) {
 		var newPath = dirMap[ partial ]
 			? path.join( target, dirMap[ partial ] )
 			: path.join( target, partial );
-		var dir = path.dirname( newPath );
 		if( path.extname( file ) === ".blu" ) {
 			var ejsFn = ejs.compile( content, imports );
 			content = ejsFn( state );
@@ -30,9 +27,6 @@ function expand( fs, base, target, context, state, files, structure ) {
 			newPath = newPath.replace( /[.]blu$/, "" );
 		}
 		if( content.trim() ) {
-			if ( !nodeFS.existsSync( dir ) ) {
-				mkdirp.sync( dir );
-			}
 			fs.write( newPath, content );
 		}
 	}


### PR DESCRIPTION
Hey @arobson, another small optimization. Yo will automatically create missing directories, and so this PR just removes the work to make directories and check for their existence via node.

I also removed `class-extend` as we aren't using that directly any more.
